### PR TITLE
Add d3dcompiler_47 dependency to fix Advanced 3D, and bump dependency versions.

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -56,8 +56,8 @@ mv gdiplus.dll ./assets/
 
 # Download dxvk
 echo Downloading dxvk...
-curl -LO https://github.com/doitsujin/dxvk/releases/download/v2.7.1/dxvk-2.7.1.tar.gz
-mv dxvk-2.7.1.tar.gz ./assets/dxvk.tar.gz
+curl -LO https://github.com/doitsujin/dxvk/releases/download/v2.7.1/dxvk-3.0.1.tar.gz
+mv dxvk-3.0.1.tar.gz ./assets/dxvk.tar.gz
 
 echo --------------------------------------------
 echo Done!

--- a/prepare.sh
+++ b/prepare.sh
@@ -28,9 +28,9 @@ rm cabextract-1.11-1.x86_64.rpm
 
 # Download Wine
 echo Downloading Wine...
-curl -LO https://github.com/Kron4ek/Wine-Builds/releases/download/11.3/wine-11.3-staging-tkg-amd64-wow64.tar.xz
-mkdir -p ./assets/wine && tar Jxf wine-11.3-staging-tkg-amd64-wow64.tar.xz --strip-components=1 -C ./assets/wine
-rm wine-11.3-staging-tkg-amd64-wow64.tar.xz
+curl -LO https://github.com/Kron4ek/Wine-Builds/releases/download/11.12/wine-11.12-staging-tkg-amd64-wow64.tar.xz
+mkdir -p ./assets/wine && tar Jxf wine-11.12-staging-tkg-amd64-wow64.tar.xz --strip-components=1 -C ./assets/wine
+rm wine-11.12-staging-tkg-amd64-wow64.tar.xz
 
 
 # Download Visual C++ Redistributable Runtimes

--- a/src/installationthread.py
+++ b/src/installationthread.py
@@ -259,16 +259,16 @@ class InstallationThread(ProcessThread):
             self.log_signal.emit('[WARNING] Installation folder not found or matched root path. No folder was deleted.')
 
     def install_nvidia_libs(self):
-        download_url = "https://github.com/SveSop/nvidia-libs/releases/download/v0.8.5/nvidia-libs-v0.8.5.tar.xz"
+        download_url = "https://github.com/SveSop/nvidia-libs/releases/download/v1.0.2/nvidia-libs-v1.0.2.tar.xz"
         nvidia_libs_dir = get_wineprefix_dir().joinpath("nvidia-libs")
         os.makedirs(nvidia_libs_dir, exist_ok=True)
-        tar_file = nvidia_libs_dir.joinpath("nvidia-libs-v0.8.5.tar.xz")
+        tar_file = nvidia_libs_dir.joinpath("nvidia-libs-v1.0.2.tar.xz")
 
         self.download_file_to(download_url, tar_file)
         self.log_signal.emit("[DEBUG] Download completed.")
         self.log_signal.emit("[DEBUG] Extracting NVIDIA libs...")
 
-        extract_dir = nvidia_libs_dir.joinpath("nvidia-libs-v0.8.5")
+        extract_dir = nvidia_libs_dir.joinpath("nvidia-libs-v1.0.2")
 
         self.unpack_tar(tar_file, nvidia_libs_dir)
 

--- a/src/installationthread.py
+++ b/src/installationthread.py
@@ -79,7 +79,7 @@ class InstallationThread(ProcessThread):
             
             self.progress_signal.emit(60)
 
-            tweaks = ['corefonts']
+            tweaks = ['corefonts', 'd3dcompiler_47']
             for tweak in tweaks:
                 self.log_signal.emit(f'[DEBUG] Installing {tweak} with winetricks')
                 self.run_command(['winetricks', '-q', tweak], in_prefix=True)


### PR DESCRIPTION
this PR fixes advanced 3d & also updates dependencies (new versions tested by me personally :p)