### PR TITLE
XDG Desktop Portal file dialog patches

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -32,6 +32,12 @@ curl -LO https://github.com/Kron4ek/Wine-Builds/releases/download/11.12/wine-11.
 mkdir -p ./assets/wine && tar Jxf wine-11.12-staging-tkg-amd64-wow64.tar.xz --strip-components=1 -C ./assets/wine
 rm wine-11.12-staging-tkg-amd64-wow64.tar.xz
 
+# Download comdlg32 patches
+echo Downloading & applying file dialog patches...
+curl -LO https://github.com/buwryme/wine-xdg/releases/download/binaries/comdlg32.dll
+curl -LO https://github.com/buwryme/wine-xdg/releases/download/binaries/comdlg32.so
+mv comdlg32.so assets/wine/lib/x86_64-unix/comdlg32.so
+mv comdlg32.dll assets/wine/lib/x86_64-windows/comdlg32.dll
 
 # Download Visual C++ Redistributable Runtimes
 echo Downloading Visual C++ Redistributable Runtimes...


### PR DESCRIPTION
this pr adds xdg desktop file dialogs (your system's file dialog, qt or gtk...) in place of wine's implementation

this practice has been tested by me , it works :p