### PR TITLE
add env variable WINE_USE_PORTAL=1 to ae thread

### DIFF
--- a/src/processthread.py
+++ b/src/processthread.py
@@ -135,7 +135,7 @@ class ProcessThread(QThread):
             fl = fcntl.fcntl(fd, fcntl.F_GETFL)
             fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
-    def run_command(self, command: list, cwd: str = None, in_prefix: bool = False):
+    def run_command(self, command: list, cwd: str = None, in_prefix: bool = False, use_portal: bool = False):
         self.log_signal.emit(f'[COMMAND] Running command: {" ".join(command)}')
         self._is_cancelled = False
 
@@ -143,6 +143,8 @@ class ProcessThread(QThread):
         if in_prefix:
             env['WINEPREFIX'] = get_wineprefix_dir()
             env['PATH'] = get_wine_bin_path_env(env.get('PATH', os.defpath))
+        if use_portal:
+            env['WINE_USE_PORTAL'] = '1'
         
         try:
             process = subprocess.Popen(

--- a/src/runaethread.py
+++ b/src/runaethread.py
@@ -4,7 +4,7 @@ from src.runexethread import RunExeThread
 
 class RunAEThread(RunExeThread):
     def __init__(self):
-        super().__init__(['AfterFX.exe'])
+        super().__init__(['AfterFX.exe'], use_portal=True)
     
     def add_aep_file_arg(self, aep_file: str):
         self.exe_args.append('Z:' + aep_file)

--- a/src/runexethread.py
+++ b/src/runexethread.py
@@ -2,15 +2,17 @@ from src.processthread import ProcessThread
 from src.utils import get_ae_install_dir
 
 class RunExeThread(ProcessThread):
-    def __init__(self, exe_args: list):
+    def __init__(self, exe_args: list, use_portal: bool = False):
         super().__init__()
         self.exe_args = exe_args
+        self.use_portal = use_portal
     
     def run(self):
         self.run_command(
             ['wine'] + self.exe_args, 
             cwd=get_ae_install_dir(),
-            in_prefix=True
+            in_prefix=True,
+            use_portal=self.use_portal
         )
 
         self.finished_signal.emit(True)


### PR DESCRIPTION
without the environment variable, xdg desktop portal sometimes doesn't activate and uses wine's builtin instead